### PR TITLE
Updated code with a missing HTTP header

### DIFF
--- a/ElasticSearchLambda/ZombieWorkshopSearchIndexing.js
+++ b/ElasticSearchLambda/ZombieWorkshopSearchIndexing.js
@@ -48,6 +48,7 @@ function postToES(doc, context) {
     req.region = esDomain.region;
     req.headers['presigned-expires'] = false;
     req.headers['Host'] = endpoint.host;
+    req.headers['Content-Type'] = 'application/json';
     req.body = doc;
 
     console.log('Creating the Signer for the post request');


### PR DESCRIPTION
The Content Type header is required by the ElasticSearch service.