### PR TITLE
Update postToES to include Content-Type header

### DIFF
--- a/ElasticSearchLambda/ZombieWorkshopSearchIndexing.js
+++ b/ElasticSearchLambda/ZombieWorkshopSearchIndexing.js
@@ -48,6 +48,7 @@ function postToES(doc, context) {
     req.region = esDomain.region;
     req.headers['presigned-expires'] = false;
     req.headers['Host'] = endpoint.host;
+    req.headers['Content-Type'] = 'application/json'
     req.body = doc;
 
     console.log('Creating the Signer for the post request');


### PR DESCRIPTION
Failure to include the header results in the following error (ES 6.2):

{ "error": "Content-Type header is missing", "status": 406 }